### PR TITLE
Add `HalfSpace`

### DIFF
--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -14,6 +14,7 @@
 #include <BRepBuilderAPI_MakeVertex.hxx>
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepBuilderAPI_Transform.hxx>
+#include <BRepClass3d_SolidClassifier.hxx>
 #include <BRepFeat_MakeCylindricalHole.hxx>
 #include <BRepFeat_MakeDPrism.hxx>
 #include <BRepFilletAPI_MakeChamfer.hxx>
@@ -72,6 +73,7 @@
 #include <TColgp_Array1OfDir.hxx>
 #include <TColgp_HArray1OfPnt.hxx>
 #include <TopAbs_ShapeEnum.hxx>
+#include <TopAbs_State.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopTools_HSequenceOfShape.hxx>
 #include <TopoDS.hxx>

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -33,6 +33,7 @@
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <BRepPrimAPI_MakeCone.hxx>
 #include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepPrimAPI_MakeHalfSpace.hxx>
 #include <BRepPrimAPI_MakePrism.hxx>
 #include <BRepPrimAPI_MakeRevol.hxx>
 #include <BRepPrimAPI_MakeSphere.hxx>

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1,5 +1,6 @@
 #[cxx::bridge]
 pub mod ffi {
+
     #[repr(u32)]
     #[derive(Debug)]
     pub enum TopAbs_ShapeEnum {
@@ -60,6 +61,15 @@ pub mod ffi {
         GeomAbs_Arc,
         GeomAbs_Tangent,
         GeomAbs_Intersection,
+    }
+
+    #[repr(u32)]
+    #[derive(Debug)]
+    pub enum TopAbs_State {
+        TopAbs_IN,
+        TopAbs_OUT,
+        TopAbs_ON,
+        TopAbs_UNKNOWN,
     }
 
     unsafe extern "C++" {
@@ -1414,6 +1424,17 @@ pub mod ffi {
         type BRepBndLib;
 
         pub fn BRepBndLib_Add(shape: &TopoDS_Shape, bb: Pin<&mut Bnd_Box>, use_triangulation: bool);
+
+        // BRepClass3D
+        type TopAbs_State;
+        type BRepClass3d_SolidClassifier;
+
+        #[cxx_name = "construct_unique"]
+        pub fn BRepClass3d_SolidClassifier_ctor() -> UniquePtr<BRepClass3d_SolidClassifier>;
+
+        pub fn Load(self: Pin<&mut BRepClass3d_SolidClassifier>, shape: &TopoDS_Shape);
+        pub fn Perform(self: Pin<&mut BRepClass3d_SolidClassifier>, point: &gp_Pnt, tolerance: f64);
+        pub fn State(self: &BRepClass3d_SolidClassifier) -> TopAbs_State;
     }
 }
 

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -707,6 +707,17 @@ pub mod ffi {
         pub fn Build(self: Pin<&mut BRepPrimAPI_MakeTorus>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepPrimAPI_MakeTorus) -> bool;
 
+        // HalfSpace
+        type BRepPrimAPI_MakeHalfSpace;
+
+        #[cxx_name = "construct_unique"]
+        pub fn BRepPrimAPI_MakeHalfSpace_ctor(
+            face: &TopoDS_Face,
+            positive_point: &gp_Pnt,
+        ) -> UniquePtr<BRepPrimAPI_MakeHalfSpace>;
+
+        pub fn Solid(self: &BRepPrimAPI_MakeHalfSpace) -> &TopoDS_Solid;
+
         // BRepLib
         pub fn BRepLibBuildCurves3d(shape: &TopoDS_Shape) -> bool;
 

--- a/crates/opencascade/src/primitives.rs
+++ b/crates/opencascade/src/primitives.rs
@@ -6,6 +6,7 @@ mod boolean_shape;
 mod compound;
 mod edge;
 mod face;
+mod half_space;
 mod shape;
 mod shell;
 mod solid;

--- a/crates/opencascade/src/primitives/half_space.rs
+++ b/crates/opencascade/src/primitives/half_space.rs
@@ -20,9 +20,9 @@ impl HalfSpace {
 
 #[cfg(test)]
 mod test {
-    use crate::workplane::Workplane;
-
     use super::*;
+    use crate::{primitives::IntoShape, workplane::Workplane};
+    use glam::DVec3;
 
     fn unit_face() -> Face {
         let sk = Workplane::xy().sketch();
@@ -37,13 +37,25 @@ mod test {
         )
     }
 
+    fn contains(solid: &Solid, point: &DVec3, tolerance: f64) -> ffi::TopAbs_State {
+        let mut sc = ffi::BRepClass3d_SolidClassifier_ctor();
+        sc.pin_mut().Load(&solid.into_shape().inner);
+        sc.pin_mut().Perform(&ffi::new_point(point.x, point.y, point.z), tolerance);
+        sc.State()
+    }
+
     #[test]
     fn create_half_space() {
         let f = unit_face();
 
         let s = HalfSpace::new(&f).solid();
 
-        assert!(s.contains(&glam::dvec3(0.0, 0.0, 0.001), 0.0001));
-        assert!(!s.contains(&glam::dvec3(0.0, 0.0, -0.001), 0.0001));
+        assert_eq!(contains(&s, &glam::dvec3(0.0, 0.0, 0.0), 0.01), ffi::TopAbs_State::TopAbs_ON);
+        assert_eq!(contains(&s, &glam::dvec3(0.0, 0.0, 0.1), 0.01), ffi::TopAbs_State::TopAbs_IN);
+        assert_eq!(
+            contains(&s, &glam::dvec3(0.0, 0.0, 2e64 - 1.0), 0.01),
+            ffi::TopAbs_State::TopAbs_IN
+        );
+        assert_eq!(contains(&s, &glam::dvec3(0.0, 0.0, -0.1), 0.01), ffi::TopAbs_State::TopAbs_OUT);
     }
 }

--- a/crates/opencascade/src/primitives/half_space.rs
+++ b/crates/opencascade/src/primitives/half_space.rs
@@ -1,6 +1,5 @@
 use super::{face::Face, solid::Solid};
 use cxx::UniquePtr;
-use glam::DVec3;
 use opencascade_sys::ffi;
 
 pub struct HalfSpace {

--- a/crates/opencascade/src/primitives/half_space.rs
+++ b/crates/opencascade/src/primitives/half_space.rs
@@ -1,0 +1,50 @@
+use super::{face::Face, solid::Solid};
+use cxx::UniquePtr;
+use glam::DVec3;
+use opencascade_sys::ffi;
+
+pub struct HalfSpace {
+    pub(crate) inner: UniquePtr<ffi::BRepPrimAPI_MakeHalfSpace>,
+}
+impl HalfSpace {
+    pub fn new(face: &Face) -> Self {
+        let p = face.center_of_mass() + face.normal_at_center();
+        Self {
+            inner: ffi::BRepPrimAPI_MakeHalfSpace_ctor(&face.inner, &ffi::new_point(p.x, p.y, p.z)),
+        }
+    }
+
+    pub fn solid(&self) -> Solid {
+        Solid::from_solid(self.inner.Solid())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::workplane::Workplane;
+
+    use super::*;
+
+    fn unit_face() -> Face {
+        let sk = Workplane::xy().sketch();
+        // Create a right triangle with CCW winding in quadrant 1
+        // This is to ensure that the derived normal is along the positive Z axis
+        Face::from_wire(
+            &sk //
+                .line_to(1.0, 0.0)
+                .line_to(0.0, 1.0)
+                .line_to(0.0, 0.0)
+                .wire(),
+        )
+    }
+
+    #[test]
+    fn create_half_space() {
+        let f = unit_face();
+
+        let s = HalfSpace::new(&f).solid();
+
+        assert!(s.contains(&glam::dvec3(0.0, 0.0, 0.001), 0.0001));
+        assert!(!s.contains(&glam::dvec3(0.0, 0.0, -0.001), 0.0001));
+    }
+}

--- a/crates/opencascade/src/primitives/half_space.rs
+++ b/crates/opencascade/src/primitives/half_space.rs
@@ -1,16 +1,29 @@
 use super::{face::Face, solid::Solid};
 use cxx::UniquePtr;
+use glam::DVec3;
 use opencascade_sys::ffi;
 
 pub struct HalfSpace {
     pub(crate) inner: UniquePtr<ffi::BRepPrimAPI_MakeHalfSpace>,
 }
 impl HalfSpace {
-    pub fn new(face: &Face) -> Self {
-        let p = face.center_of_mass() + face.normal_at_center();
+    /// Create a `HalfSpace` from a `Face` and a point that indicates on which
+    /// side of the face the solid half of the space should be located.
+    pub fn new(face: &Face, point: &DVec3) -> Self {
         Self {
-            inner: ffi::BRepPrimAPI_MakeHalfSpace_ctor(&face.inner, &ffi::new_point(p.x, p.y, p.z)),
+            inner: ffi::BRepPrimAPI_MakeHalfSpace_ctor(
+                &face.inner,
+                &ffi::new_point(point.x, point.y, point.z),
+            ),
         }
+    }
+
+    /// Create a `HalfSpace` from a `Face`, using its center and normal to
+    /// create the positive side. The `normal_vector_sign` can be used to invert
+    /// the side of the face that is used to create the solid.
+    pub fn from_face(face: &Face, normal_vector_sign: f64) -> Self {
+        let p = face.center_of_mass() + face.normal_at_center() * normal_vector_sign.signum();
+        Self::new(face, &p)
     }
 
     pub fn solid(&self) -> Solid {
@@ -45,17 +58,47 @@ mod test {
     }
 
     #[test]
-    fn create_half_space() {
-        let f = unit_face();
+    fn create_new() {
+        let s = HalfSpace::new(&unit_face(), &glam::dvec3(0.0, 0.0, 1.0)).solid();
 
-        let s = HalfSpace::new(&f).solid();
-
-        assert_eq!(contains(&s, &glam::dvec3(0.0, 0.0, 0.0), 0.01), ffi::TopAbs_State::TopAbs_ON);
-        assert_eq!(contains(&s, &glam::dvec3(0.0, 0.0, 0.1), 0.01), ffi::TopAbs_State::TopAbs_IN);
         assert_eq!(
-            contains(&s, &glam::dvec3(0.0, 0.0, 2e64 - 1.0), 0.01),
+            //
+            contains(&s, &glam::dvec3(0.0, 0.0, 0.0), 0.01),
+            ffi::TopAbs_State::TopAbs_ON
+        );
+        assert_eq!(
+            //
+            contains(&s, &glam::dvec3(0.0, 0.0, 0.1), 0.01),
             ffi::TopAbs_State::TopAbs_IN
         );
-        assert_eq!(contains(&s, &glam::dvec3(0.0, 0.0, -0.1), 0.01), ffi::TopAbs_State::TopAbs_OUT);
+        assert_eq!(
+            // NOTE: f64::MAX is not contained. From simple trial-and-error, this
+            // is the largest value that is still contained.
+            contains(&s, &glam::dvec3(0.0, 0.0, 2.0 * 10f64.powf(100.0)), 0.01),
+            ffi::TopAbs_State::TopAbs_IN
+        );
+        assert_eq!(
+            //
+            contains(&s, &glam::dvec3(0.0, 0.0, -0.1), 0.01),
+            ffi::TopAbs_State::TopAbs_OUT
+        );
+    }
+
+    #[test]
+    fn create_from_face() {
+        // Test a face with an inverted normal
+        let s = HalfSpace::from_face(&unit_face(), -1.0).solid();
+
+        assert_eq!(
+            //
+            contains(&s, &glam::dvec3(0.0, 0.0, 0.1), 0.01),
+            ffi::TopAbs_State::TopAbs_OUT
+        );
+
+        assert_eq!(
+            //
+            contains(&s, &glam::dvec3(0.0, 0.0, -0.1), 0.01),
+            ffi::TopAbs_State::TopAbs_IN
+        );
     }
 }

--- a/crates/opencascade/src/primitives/solid.rs
+++ b/crates/opencascade/src/primitives/solid.rs
@@ -129,8 +129,4 @@ impl Solid {
         let wire = Wire::from_ordered_points(points)?;
         Ok(Face::from_wire(&wire).extrude(dvec3(0.0, 0.0, h)))
     }
-
-    pub fn contains(&self, point: &DVec3, tolerance: f64) -> bool {
-        todo!()
-    }
 }

--- a/crates/opencascade/src/primitives/solid.rs
+++ b/crates/opencascade/src/primitives/solid.rs
@@ -129,4 +129,8 @@ impl Solid {
         let wire = Wire::from_ordered_points(points)?;
         Ok(Face::from_wire(&wire).extrude(dvec3(0.0, 0.0, h)))
     }
+
+    pub fn contains(&self, point: &DVec3, tolerance: f64) -> bool {
+        todo!()
+    }
 }


### PR DESCRIPTION
## References
- https://dev.opencascade.org/doc/refman/html/class_b_rep_class3d___solid_classifier.html

## To do
- [x] Add `BRepClass3D_SolidClassifier` support
- [x] ~Implement `Solid::contains`~ Moved to local test function, not sure how to handle enum
- [x] Continue with `HalfSpace` tests
- [x] Finish `HalfSpace::from_*` functions