### PR TITLE
Add sync impl for topo ds shape

### DIFF
--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1514,6 +1514,7 @@ unsafe impl Send for ffi::TopoDS_Shell {}
 unsafe impl Send for ffi::TopoDS_Solid {}
 unsafe impl Send for ffi::TopoDS_Compound {}
 unsafe impl Send for ffi::TopoDS_Shape {}
+unsafe impl Sync for ffi::TopoDS_Shape {}
 
 unsafe impl Send for ffi::TopExp_Explorer {}
 unsafe impl Send for ffi::BRepFilletAPI_MakeChamfer {}


### PR DESCRIPTION
We have been using this successfully for a while now. The main caveat is that we are always using `Shape::transform` to effectively clone the `Shape` instance when using them across threads.