### PR TITLE
Update for msvc errors

### DIFF
--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -56,6 +56,10 @@ fn main() {
         build.define("OCC_CONVERT_SIGNALS", "TRUE");
     }
 
+    if target.to_lowercase().contains("msvc") {
+        build.flag("/EHsc");
+    }
+
     if let "windows" = std::env::consts::OS {
         let current = std::env::current_dir().unwrap();
         build.include(current.parent().unwrap());

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -584,22 +584,18 @@ inline void BRepBndLib_Add(const TopoDS_Shape &shape, Bnd_Box &box, const Standa
 
 // HLRAlgo
 
-typedef opencascade::handle<HLRBRep_Algo> Handle_HLRBRep_Algo;
+using HandleHLRBRepAlgo = Handle_HLRBRep_Algo;
 
-inline std::unique_ptr<Handle_HLRBRep_Algo> Handle_HLRBRep_Algo_ctor() {
-  Handle(HLRBRep_Algo) hlr = new HLRBRep_Algo;
-  return std::unique_ptr<Handle_HLRBRep_Algo>(new Handle_HLRBRep_Algo(hlr));
+inline std::unique_ptr<HandleHLRBRepAlgo> HandleHLRBRepAlgo_ctor() {
+  return std::unique_ptr<HandleHLRBRepAlgo>(new HandleHLRBRepAlgo(new HLRBRep_Algo));
 }
 
-inline void HLRBRep_Algo_Add(const Handle_HLRBRep_Algo &algo, const TopoDS_Shape &s) {
-  auto a = algo.get();
-  a->Add(s);
+inline void HLRBRep_Algo_Add(const HandleHLRBRepAlgo &algo, const TopoDS_Shape &s) { algo->Add(s); }
+inline void HLRBRep_Algo_Projector(const HandleHLRBRepAlgo &algo, const HLRAlgo_Projector &p) {
+  algo->Projector(p);
 }
-inline void HLRBRep_Algo_Projector(const Handle_HLRBRep_Algo &algo, const HLRAlgo_Projector &p) {
-  return algo.get()->Projector(p);
-}
-inline void HLRBRep_Algo_Update(const Handle_HLRBRep_Algo &algo) { return algo.get()->Update(); }
-inline void HLRBRep_Algo_Hide(const Handle_HLRBRep_Algo &algo) { return algo.get()->Hide(); }
+inline void HLRBRep_Algo_Update(const HandleHLRBRepAlgo &algo) { algo->Update(); }
+inline void HLRBRep_Algo_Hide(const HandleHLRBRepAlgo &algo) { algo->Hide(); }
 
 inline std::unique_ptr<TopoDS_Shape> HLRBRep_HLRToShape_VCompound(HLRBRep_HLRToShape &ts) {
   auto s = new TopoDS_Shape;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1485,12 +1485,12 @@ pub mod ffi {
 
         // HLRBrep
         // Shape -> Plane projection
-        type Handle_HLRBRep_Algo;
-        pub fn Handle_HLRBRep_Algo_ctor() -> UniquePtr<Handle_HLRBRep_Algo>;
-        pub fn HLRBRep_Algo_Add(algo: &Handle_HLRBRep_Algo, shape: &TopoDS_Shape);
-        pub fn HLRBRep_Algo_Projector(algo: &Handle_HLRBRep_Algo, projector: &HLRAlgo_Projector);
-        pub fn HLRBRep_Algo_Update(algo: &Handle_HLRBRep_Algo);
-        pub fn HLRBRep_Algo_Hide(algo: &Handle_HLRBRep_Algo);
+        type HandleHLRBRepAlgo;
+        pub fn HandleHLRBRepAlgo_ctor() -> UniquePtr<HandleHLRBRepAlgo>;
+        pub fn HLRBRep_Algo_Add(algo: &HandleHLRBRepAlgo, shape: &TopoDS_Shape);
+        pub fn HLRBRep_Algo_Projector(algo: &HandleHLRBRepAlgo, projector: &HLRAlgo_Projector);
+        pub fn HLRBRep_Algo_Update(algo: &HandleHLRBRepAlgo);
+        pub fn HLRBRep_Algo_Hide(algo: &HandleHLRBRepAlgo);
 
         type HLRAlgo_Projector;
         #[cxx_name = "construct_unique"]
@@ -1505,7 +1505,7 @@ pub mod ffi {
         type HLRBRep_TypeOfResultingEdge;
         #[cxx_name = "construct_unique"]
         pub fn HLRBRep_HLRToShape_ctor(
-            hlr_algo: &Handle_HLRBRep_Algo,
+            hlr_algo: &HandleHLRBRepAlgo,
         ) -> UniquePtr<HLRBRep_HLRToShape>;
         pub fn HLRBRep_HLRToShape_VCompound(
             ts: Pin<&mut HLRBRep_HLRToShape>,

--- a/crates/opencascade/src/hlr.rs
+++ b/crates/opencascade/src/hlr.rs
@@ -61,7 +61,7 @@ pub fn filter(
     plane_normal: &DVec3,
     project_edges_to_plane: bool,
 ) -> (DMat4, Shape) {
-    let algo = ffi::Handle_HLRBRep_Algo_ctor();
+    let algo = ffi::HandleHLRBRepAlgo_ctor();
     ffi::HLRBRep_Algo_Add(&algo, &shape.inner);
     let proj = ffi::HLRAlgo_Projector_from_ax2(&ffi::gp_Ax2_ctor(
         &ffi::new_point(plane_origin.x, plane_origin.y, plane_origin.z),


### PR DESCRIPTION
## Summary
- Update `Handle_HLRBRep_Algo` naming to avoid collision with equivalent msvc-expanded macro 
  - Due to: `opencascade-sys-aa341a5bb48678ba\out\cxxbridge\crate\opencascade-sys/include/wrapper.hxx(587): error C2371: 'Handle_HLRBRep_Algo': redefinition; different basic types`
- Update references to type
- Update [msvc build args](https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170) to eliminate exception handling warning
  - Due to: `OCCT\include\IMeshTools_ModelBuilder.hxx(50): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc`

## Description
After getting a working msvc build environment set up, I was able to pull out the relevant parts of the build log and use copilot to figure out what was wrong with this.

It turns out that msvc expands macros _within_ OCC a bit differently than clang and gcc. There is an existing macro that expands to the type name `Handle_HLRBRep_Algo`. This meant that the matching type name that I added in #5 in `wrapper.hxx` conflicted, but only on msvc builds. This caused the cascading failures that we saw windows related to incompatible types.

I chose to use the same name, but without `_` for now so that the names more closely match the existing wrapper types. In general, I think a better pattern would be to prefix the type names with `Rust_` or `Wrap_` or some other prefix that OCC is not using internally to avoid this failure mode in the future.